### PR TITLE
set Automatic-Module-Name for xercesImpl.jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -351,6 +351,7 @@ Authors:
                    org/w3c/dom/html/HTMLDOMImplementation.class"
          manifest="${build.dir}/manifest.xerces">
       <manifest>
+        <attribute name="Automatic-Module-Name" value="org.apache.xerces.impl"/>
         <attribute name="Ant-Version" value="${ant.version}"/>
       </manifest>
       <metainf dir="." includes="LICENSE,NOTICE"/>


### PR DESCRIPTION
Ideally xerces should fully support JPMS but whilst it's still targeting JDK 8 perhaps it's worth defining an Automatic-Module-Name