### PR TITLE
website: add security page

### DIFF
--- a/docs/docs-book.xml
+++ b/docs/docs-book.xml
@@ -26,6 +26,8 @@
            id='charter' source='charter.xml'/>
  <releases label='Release Info' title='Release Information'
            id='releases' source='releases.xml'/>
+ <document label='Security' title='Security'
+           id='security' source='security.xml'/>
  <separator/>
  <document label='Installation' title='Installation Instructions'
            id='install' source='install.xml'/>

--- a/docs/security.xml
+++ b/docs/security.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<!DOCTYPE s1 SYSTEM 'dtd/document.dtd'>
+<s1 title="Security">
+<s2 title="Security Model">
+
+By default, Xerces does what the XML specifications require. In some cases, this may not be appropriate behavior when working with untrusted input. There are multiple methods for blocking access to external entities and for disallowing DOCTYPE declarations, and it is up to the downstream user of Xerces-J to block/reject these constructs where appropriate.
+
+</s2>
+<s2 title="Reporting">
+
+<p>
+If you think you have found a security issue in Apache Xerces, please follow the <jump href='https://security.apache.org/report-code'>reporting guidelines</jump>.
+</p>
+<p>
+Results from source code security analyzers are not accepted without additional analysis showing that the problem indeed violates the project's security model, as such tools commonly produce many false positives.
+</p>
+
+</s2>
+</s1>


### PR DESCRIPTION
Based on https://xalan.apache.org/

Should we add similar wording as on https://xerces.apache.org/xerces-c/secadv.html or is Xerces-J in better shape?