### PR TITLE
Use Character.valueOf instead of deprecated Character constructor

### DIFF
--- a/src/org/apache/xerces/xpointer/ElementSchemePointer.java
+++ b/src/org/apache/xerces/xpointer/ElementSchemePointer.java
@@ -770,7 +770,7 @@ final class ElementSchemePointer implements XPointerPart {
                     // An invalid child sequence character
                     if (child == 0) {
                         reportError("InvalidChildSequenceCharacter",
-                                new Object[] { new Character((char) ch) });
+                                new Object[] { Character.valueOf((char) ch) });
                         return false;
                     }
 

--- a/src/org/apache/xml/serialize/EncodingInfo.java
+++ b/src/org/apache/xml/serialize/EncodingInfo.java
@@ -140,7 +140,7 @@ public class EncodingInfo {
         // Attempt to use the CharsetEncoder to determine whether the character is printable.
         if (fCharsetEncoder != null) {
             try {
-                fArgsForMethod[0] = new Character(ch);
+                fArgsForMethod[0] = Character.valueOf(ch);
                 return ((Boolean) CharsetMethods.fgCharsetEncoderCanEncodeMethod.invoke(fCharsetEncoder, fArgsForMethod)).booleanValue();
             } 
             catch (Exception e) {
@@ -173,7 +173,7 @@ public class EncodingInfo {
             }
         }
         try {
-            fArgsForMethod[0] = new Character(ch);
+            fArgsForMethod[0] = Character.valueOf(ch);
             return ((Boolean) CharToByteConverterMethods.fgCanConvertMethod.invoke(fCharToByteConverter, fArgsForMethod)).booleanValue();
         } 
         catch (Exception e) {


### PR DESCRIPTION
simple change to stop using deprecated `new Character(ch)` and instead do `Character.valueOf(ch)`