### PR TITLE
protect master branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,11 @@
 github:
   description: "Apache Xerces-J"
   homepage: https://xerces.apache.org/xerces2-j/
-  
+  protected_branches:
+    main:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+      required_pull_request_reviews:
+        require_last_push_approval: true
+        required_approving_review_count: 1


### PR DESCRIPTION
I'm trying to lock down the repo a bit more to protect against increasing supply chain attacks including ones that steal GitHub credentials and use it to launch not just malware but self-propagating worms:

https://www.youtube.com/watch?v=ZrD9MC_BXGk

This hasn't hit Java yet that I know of, but I fear that's only a matter of time. This PR won't completely resolve the problem, but maybe gives us a bit more chance of noticing a nefarious worm.

