### PR TITLE
Convert dom.registry.Test to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="dom/registry/Test.class"/>
            </fileset>
          </batchtest>
 
@@ -964,12 +965,6 @@ Authors:
     <echo message="Running xinclude.Test..." />
     <java fork="yes"
           classname="xinclude.Test"
-          classpathref="test.classpath"
-          failOnError="yes">
-    </java>
-    <echo message="Running dom.registry.Test..." />
-    <java fork="yes"
-          classname="dom.registry.Test"
           classpathref="test.classpath"
           failOnError="yes">
     </java>

--- a/tests/dom/registry/Test.java
+++ b/tests/dom/registry/Test.java
@@ -23,13 +23,12 @@ import org.apache.xerces.dom.DOMImplementationImpl;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 
-import dom.util.Assertion;
+import junit.framework.TestCase;
 
-public class Test {
+public class Test extends TestCase {
 
-    public static void main(String argv[])
-    {                                  
-        
+    public void testRegistry()
+    {
         System.out.println("Running dom.registry.Test...");
         // set DOMImplementationSource
         System.setProperty(DOMImplementationRegistry.PROPERTY,
@@ -39,30 +38,30 @@ public class Test {
         DOMImplementationRegistry registry = null;
         try {
             registry = DOMImplementationRegistry.newInstance();
-            Assertion.verify(registry != null);
+            assertNotNull("registry should not be null", registry);
         } catch (Exception e) {
-            e.printStackTrace();
+            fail("Unexpected exception: " + e.getMessage());
         }
 
         try {
             DOMImplementation i = registry.getDOMImplementation("XML");
 
-            Assertion.verify(i ==
+            assertSame(i,
                              CoreDOMImplementationImpl.getDOMImplementation());
 
         } catch (Exception e) {
-            e.printStackTrace();
+            fail("Unexpected exception: " + e.getMessage());
         }
 
         try {
             DOMImplementation i =
                 registry.getDOMImplementation("XML MutationEvents");
 
-            Assertion.verify(i ==
+            assertSame(i,
                              DOMImplementationImpl.getDOMImplementation());
 
         } catch (Exception e) {
-            e.printStackTrace();
+            fail("Unexpected exception: " + e.getMessage());
         }
     }
 }    


### PR DESCRIPTION
Convert the dom.registry.Test test harness from a main()-driven to JUnit 3.
- Extends TestCase
- Replaces broken Assertion.verify calls with proper JUnit assertions
- Registered in batchtest and old java task removed in build.xml