### PR TITLE
Convert dom.rename.Test to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="dom/rename/Test.class"/>
            </fileset>
          </batchtest>
 

--- a/tests/dom/rename/Test.java
+++ b/tests/dom/rename/Test.java
@@ -17,6 +17,8 @@
 
 package dom.rename;
 
+import junit.framework.TestCase;
+
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -27,7 +29,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import dom.ParserWrapper;
-import dom.util.Assertion;
 
 /**
  * A simple program to test Document.getElementById() and the management
@@ -39,7 +40,7 @@ import dom.util.Assertion;
  *
  * @version $Id$
  */
-public class Test implements UserDataHandler {
+public class Test extends TestCase implements UserDataHandler {
 
     //
     // Constants
@@ -77,138 +78,203 @@ public class Test implements UserDataHandler {
     // Xerces specific feature
     protected static final boolean DEFAULT_DEFERRED_DOM = true;
 
-    //
-    // Public methods
-    //
+    private Document document;
+
+    protected void setUp() throws Exception {
+        ParserWrapper parser = (ParserWrapper)
+            Class.forName(DEFAULT_PARSER_NAME).newInstance();
+        try {
+            parser.setFeature(NAMESPACES_FEATURE_ID, DEFAULT_NAMESPACES);
+        }
+        catch (SAXException e) {
+            // ignore
+        }
+        try {
+            parser.setFeature(VALIDATION_FEATURE_ID, DEFAULT_VALIDATION);
+        }
+        catch (SAXException e) {
+            // ignore
+        }
+        try {
+            parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID,
+                              DEFAULT_SCHEMA_VALIDATION);
+        }
+        catch (SAXException e) {
+            // ignore
+        }
+        try {
+            parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID,
+                              DEFAULT_SCHEMA_FULL_CHECKING);
+        }
+        catch (SAXException e) {
+            // ignore
+        }
+        if (parser instanceof dom.wrappers.Xerces) {
+            try {
+                parser.setFeature(DEFERRED_DOM_FEATURE_ID,
+                                  DEFAULT_DEFERRED_DOM);
+            }
+            catch (SAXException e) {
+                // ignore
+            }
+        }
+        try {
+            document = parser.parse("tests/dom/rename/input.xml");
+        }
+        catch (SAXParseException e) {
+            fail("Parse error: " + e.getMessage());
+        }
+        catch (Exception e) {
+            String msg = e.getMessage();
+            if (e instanceof SAXException) {
+                msg = ((SAXException)e).getException().getMessage();
+            }
+            fail("Parse error: " + msg);
+        }
+    }
+
+    public void testRename() {
+        doTestRename(document);
+    }
 
     /** Performs the actual test. */
-    public void test(Document doc) {
+    public void doTestRename(Document doc) {
 
         System.out.println("DOM rename Test...");
 
 	// getting the first "email" element
 	NodeList elements = doc.getElementsByTagName("email");
 	Element child = (Element) elements.item(0);
-	Assertion.verify(child != null);
-	Assertion.equals(child.getNodeName(), "email");
+	assertTrue("child should not be null", child != null);
+	assertEquals("nodeName should be email", "email", child.getNodeName());
 
 	// default must be there
 	Attr at = child.getAttributeNode("defaultEmailAttr");
-	Assertion.verify(at != null);
-	Assertion.equals(at.getValue(), "defaultEmailValue");
-	Assertion.verify(at.getSpecified() == false);
+	assertTrue("defaultEmailAttr should not be null", at != null);
+	assertEquals("default value of defaultEmailAttr", "defaultEmailValue", at.getValue());
+	assertTrue("defaultEmailAttr should not be specified", !at.getSpecified());
 
 	// attach some data
 	child.setUserData("mydata", "yo", this);
-	Assertion.equals((String) child.getUserData("mydata"), "yo");
+	assertEquals("user data should be 'yo'", "yo", (String) child.getUserData("mydata"));
 
 	// renaming an element without a url
 	Element newChild = (Element) doc.renameNode(child, null, "url");
 
-	Assertion.equals(newChild.getNodeName(), "url");
-	Assertion.verify(newChild.getNamespaceURI() == null);
+	assertEquals("renamed node name should be url", "url", newChild.getNodeName());
+	assertTrue("namespace should be null", newChild.getNamespaceURI() == null);
 
 	// old default must no longer be there
-	Assertion.verify(newChild.hasAttribute("defaultEmailAttr") == false);
-	Assertion.verify(at.getSpecified() == true);
+	assertTrue("should not have defaultEmailAttr after rename",
+                   !newChild.hasAttribute("defaultEmailAttr"));
+	assertTrue("defaultEmailAttr should now be specified", at.getSpecified());
 
 	// new default must be there
 	at = newChild.getAttributeNode("defaultUrlAttr");
-	Assertion.verify(at != null);
-	Assertion.equals(at.getValue(), "defaultUrlValue");
-	Assertion.verify(at.getSpecified() == false);
+	assertTrue("defaultUrlAttr should not be null", at != null);
+	assertEquals("default value of defaultUrlAttr", "defaultUrlValue", at.getValue());
+	assertTrue("defaultUrlAttr should not be specified", !at.getSpecified());
 
 	// data must still be there
-	Assertion.equals((String) newChild.getUserData("mydata"), "yo");
+	assertEquals("user data should still be 'yo'", "yo", (String) newChild.getUserData("mydata"));
 	// and handler must have been called if new node was created
 	if (newChild != child) {
-	    Assertion.verify(lastOperation == UserDataHandler.NODE_RENAMED);
-	    Assertion.verify(lastKey == "mydata");
-	    Assertion.equals((String) lastData, "yo");
-	    Assertion.verify(lastSource == child);
-	    Assertion.verify(lastDestination == newChild);
+	    assertTrue("operation should be NODE_RENAMED",
+                       lastOperation == UserDataHandler.NODE_RENAMED);
+	    assertEquals("key should be 'mydata'", "mydata", lastKey);
+	    assertEquals("data should be 'yo'", "yo", (String) lastData);
+	    assertTrue("source should be original child", lastSource == child);
+	    assertTrue("destination should be new child", lastDestination == newChild);
 	    resetHandlerData();
 	}
 
 	// renaming an element with a url
 	Element newChild2 = (Element) doc.renameNode(newChild, "ns1", "foo");
 
-	Assertion.equals(newChild2.getNodeName(), "foo");
-	Assertion.equals(newChild2.getNamespaceURI(), "ns1");
-	Assertion.verify(newChild2.hasAttribute("defaultUrlAttr") == false);
+	assertEquals("renamed node name should be foo", "foo", newChild2.getNodeName());
+	assertEquals("namespace should be ns1", "ns1", newChild2.getNamespaceURI());
+	assertTrue("should not have defaultUrlAttr after rename",
+                   !newChild2.hasAttribute("defaultUrlAttr"));
 	// data must still be there
-	Assertion.equals((String) newChild2.getUserData("mydata"), "yo");
+	assertEquals("user data should still be 'yo'",
+                     "yo", (String) newChild2.getUserData("mydata"));
 	// and handler must have been called if new node was created
 	if (newChild2 != newChild) {
-	    Assertion.verify(lastOperation == UserDataHandler.NODE_RENAMED);
-	    Assertion.verify(lastKey == "mydata");
-	    Assertion.equals((String) lastData, "yo");
-	    Assertion.verify(lastSource == newChild);
-	    Assertion.verify(lastDestination == newChild2);
+	    assertTrue("operation should be NODE_RENAMED",
+                       lastOperation == UserDataHandler.NODE_RENAMED);
+	    assertEquals("key should be 'mydata'", "mydata", lastKey);
+	    assertEquals("data should be 'yo'", "yo", (String) lastData);
+	    assertTrue("source should be previous child", lastSource == newChild);
+	    assertTrue("destination should be new child2", lastDestination == newChild2);
 	    resetHandlerData();
 	}
 
 	// getting the second "email" element
 	child = (Element) elements.item(1);
-	Assertion.verify(child != null);
-	Assertion.equals(child.getNodeName(), "email");
+	assertTrue("second child should not be null", child != null);
+	assertEquals("second child nodeName should be email", "email", child.getNodeName());
 
 	// default must be there
 	at = child.getAttributeNode("defaultEmailAttr");
-	Assertion.verify(at != null);
-	Assertion.equals(at.getValue(), "defaultEmailValue");
-	Assertion.verify(at.getSpecified() == false);
+	assertTrue("second child defaultEmailAttr should not be null", at != null);
+	assertEquals("second child default value", "defaultEmailValue", at.getValue());
+	assertTrue("second child defaultEmailAttr should not be specified", !at.getSpecified());
 
 	// attach some data
 	at.setUserData("mydata", "yo", this);
-	Assertion.equals((String) at.getUserData("mydata"), "yo");
+	assertEquals("attr user data should be 'yo'", "yo", (String) at.getUserData("mydata"));
 
 	// renaming an attribute without a url
 	Attr newAt = (Attr) doc.renameNode(at, null, "foo");
-	Assertion.verify(newAt != null);
-	Assertion.equals(newAt.getNodeName(), "foo");
-	Assertion.equals(newAt.getNamespaceURI(), null);
-	Assertion.equals(newAt.getValue(), "defaultEmailValue");
-	Assertion.verify(newAt.getSpecified() == true);
-	Assertion.verify(child.hasAttribute("foo") == true);
+	assertTrue("renamed attr should not be null", newAt != null);
+	assertEquals("renamed attr name should be foo", "foo", newAt.getNodeName());
+	assertTrue("renamed attr namespace should be null", newAt.getNamespaceURI() == null);
+	assertEquals("renamed attr value should remain", "defaultEmailValue", newAt.getValue());
+	assertTrue("renamed attr should be specified", newAt.getSpecified());
+	assertTrue("child should have 'foo' attribute", child.hasAttribute("foo"));
 	// default must be back
-	Assertion.verify(child.hasAttribute("defaultEmailAttr") == true);
+	assertTrue("defaultEmailAttr should be present", child.hasAttribute("defaultEmailAttr"));
 	// data must still be there
-	Assertion.equals((String) newAt.getUserData("mydata"), "yo");
+	assertEquals("attr user data should still be 'yo'",
+                     "yo", (String) newAt.getUserData("mydata"));
 	// and handler must have been called if new node was created
 	if (newAt != at) {
-	    Assertion.verify(lastOperation == UserDataHandler.NODE_RENAMED);
-	    Assertion.verify(lastKey == "mydata");
-	    Assertion.equals((String) lastData, "yo");
-	    Assertion.verify(lastSource == at);
-	    Assertion.verify(lastDestination == newAt);
+	    assertTrue("operation should be NODE_RENAMED",
+                       lastOperation == UserDataHandler.NODE_RENAMED);
+	    assertEquals("key should be 'mydata'", "mydata", lastKey);
+	    assertEquals("data should be 'yo'", "yo", (String) lastData);
+	    assertTrue("source should be original attr", lastSource == at);
+	    assertTrue("destination should be new attr", lastDestination == newAt);
 	    resetHandlerData();
 	}
 
 	// renaming an attribute with a url
 	Attr newAt2 = (Attr) doc.renameNode(newAt, "ns1", "bar");
-	Assertion.verify(newAt2 != null);
-	Assertion.equals(newAt2.getNodeName(), "bar");
-	Assertion.equals(newAt2.getNamespaceURI(), "ns1");
-	Assertion.equals(newAt2.getValue(), "defaultEmailValue");
-	Assertion.verify(newAt2.getSpecified() == true);
-	Assertion.verify(child.hasAttributeNS("ns1", "bar") == true);
+	assertTrue("renamed attr2 should not be null", newAt2 != null);
+	assertEquals("renamed attr2 name should be bar", "bar", newAt2.getNodeName());
+	assertEquals("renamed attr2 namespace should be ns1", "ns1", newAt2.getNamespaceURI());
+	assertEquals("renamed attr2 value should remain", "defaultEmailValue", newAt2.getValue());
+	assertTrue("renamed attr2 should be specified", newAt2.getSpecified());
+	assertTrue("child should have ns1:bar attribute",
+                   child.hasAttributeNS("ns1", "bar"));
 	// data must still be there
-	Assertion.equals((String) newAt2.getUserData("mydata"), "yo");
+	assertEquals("attr2 user data should still be 'yo'",
+                     "yo", (String) newAt2.getUserData("mydata"));
 	// and handler must have been called if new node was created
 	if (newAt2 != newAt) {
-	    Assertion.verify(lastOperation == UserDataHandler.NODE_RENAMED);
-	    Assertion.verify(lastKey == "mydata");
-	    Assertion.equals((String) lastData, "yo");
-	    Assertion.verify(lastSource == newAt);
-	    Assertion.verify(lastDestination == newAt2);
+	    assertTrue("operation should be NODE_RENAMED",
+                       lastOperation == UserDataHandler.NODE_RENAMED);
+	    assertEquals("key should be 'mydata'", "mydata", lastKey);
+	    assertEquals("data should be 'yo'", "yo", (String) lastData);
+	    assertTrue("source should be previous attr", lastSource == newAt);
+	    assertTrue("destination should be new attr2", lastDestination == newAt2);
 	    resetHandlerData();
 	}
 
 
         System.out.println("done.");
 
-    } // test(Document)
+    } // doTestRename(Document)
 
     // UserDataHandler related data
     short lastOperation = -1;
@@ -245,209 +311,5 @@ public class Test implements UserDataHandler {
 	lastSource = src;
 	lastDestination = dst;
     }
-
-    //
-    // MAIN
-    //
-
-    /** Main program entry point. */
-    public static void main(String argv[]) {
-
-        // is there anything to do?
-        /*if (argv.length == 0) {
-            printUsage();
-            System.exit(1);
-        } */
-
-        
-        // variables
-        Test test = new Test();
-        ParserWrapper parser = null;
-        boolean namespaces = DEFAULT_NAMESPACES;
-        boolean validation = DEFAULT_VALIDATION;
-        boolean schemaValidation = DEFAULT_SCHEMA_VALIDATION;
-        boolean schemaFullChecking = DEFAULT_SCHEMA_FULL_CHECKING;
-        boolean deferredDom = DEFAULT_DEFERRED_DOM;
-        
-        String inputfile="tests/dom/rename/input.xml";
-        
-        // process arguments
-        for (int i = 0; i < argv.length; i++) {
-            String arg = argv[i];
-            if (arg.startsWith("-")) {
-                String option = arg.substring(1);
-                if (option.equals("p")) {
-                    // get parser name
-                    if (++i == argv.length) {
-                        System.err.println("error: Missing argument to -p"
-                                           + " option.");
-                    }
-                    String parserName = argv[i];
-
-                    // create parser
-                    try {
-                        parser = (ParserWrapper)
-                            Class.forName(parserName).newInstance();
-                    }
-                    catch (Exception e) {
-                        parser = null;
-                        System.err.println("error: Unable to instantiate "
-                                           + "parser (" + parserName + ")");
-                    }
-                    continue;
-                }
-                if (option.equalsIgnoreCase("n")) {
-                    namespaces = option.equals("n");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("v")) {
-                    validation = option.equals("v");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("s")) {
-                    schemaValidation = option.equals("s");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("f")) {
-                    schemaFullChecking = option.equals("f");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("d")) {
-                    deferredDom = option.equals("d");
-                    continue;
-                }
-                if (option.equals("h")) {
-                    printUsage();
-                    continue;
-                }
-            }
-        }
-
-            // use default parser?
-            if (parser == null) {
-
-                // create parser
-                try {
-                    parser = (ParserWrapper)
-                        Class.forName(DEFAULT_PARSER_NAME).newInstance();
-                }
-                catch (Exception e) {
-                    System.err.println("error: Unable to instantiate parser ("
-                                       + DEFAULT_PARSER_NAME + ")");
-                    System.exit(1);
-                }
-            }
-
-            // set parser features
-            try {
-                parser.setFeature(NAMESPACES_FEATURE_ID, namespaces);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + NAMESPACES_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(VALIDATION_FEATURE_ID, validation);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + VALIDATION_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID,
-                                  schemaValidation);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + SCHEMA_VALIDATION_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID,
-                                  schemaFullChecking);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + SCHEMA_FULL_CHECKING_FEATURE_ID + ")");
-            }
-
-            if (parser instanceof dom.wrappers.Xerces) {
-                try {
-                    parser.setFeature(DEFERRED_DOM_FEATURE_ID,
-                                      deferredDom);
-                }
-                catch (SAXException e) {
-                    System.err.println("warning: Parser does not support " +
-                                       "feature (" +
-                                       DEFERRED_DOM_FEATURE_ID + ")");
-                }
-            }
-
-	    Document document = null;
-            // parse file
-            try {
-                document = parser.parse(inputfile);
-            }
-            catch (SAXParseException e) {
-                // ignore
-            }
-            catch (Exception e) {
-                System.err.println("error: Parse error occurred - " +
-                                   e.getMessage());
-                Exception se = e;
-                if (e instanceof SAXException) {
-                    se = ((SAXException)e).getException();
-                }
-                if (se != null)
-                  se.printStackTrace(System.err);
-                else
-                  e.printStackTrace(System.err);
-
-		return;
-            }
-
-	    test.test(document);
-        
-
-    } // main(String[])
-
-    //
-    // Private static methods
-    //
-
-    /** Prints the usage. */
-    private static void printUsage() {
-
-        System.err.println("usage: java dom.ids.Test (options) " +
-                           "...data/personal.xml");
-        System.err.println();
-
-        System.err.println("options:");
-        System.err.println("  -p name    Select parser by name.");
-        System.err.println("  -d  | -D   Turn on/off (Xerces) deferred DOM.");
-        System.err.println("  -n  | -N   Turn on/off namespace processing.");
-        System.err.println("  -v  | -V   Turn on/off validation.");
-        System.err.println("  -s  | -S   Turn on/off Schema validation " +
-                           "support.");
-        System.err.println("             NOTE: Not supported by all parsers.");
-        System.err.println("  -f  | -F   Turn on/off Schema full checking.");
-        System.err.println("             NOTE: Requires use of -s and not " +
-                           "supported by all parsers.");
-        System.err.println("  -h         This help screen.");
-        System.err.println();
-
-        System.err.println("defaults:");
-        System.err.println("  Parser:     " + DEFAULT_PARSER_NAME);
-        System.err.println("  Xerces Deferred DOM: " +
-                           (DEFAULT_DEFERRED_DOM ? "on" : "off"));
-        System.err.println("  Namespaces: " +
-                           (DEFAULT_NAMESPACES ? "on" : "off"));
-        System.err.println("  Validation: " +
-                           (DEFAULT_VALIDATION ? "on" : "off"));
-        System.err.println("  Schema:     " +
-                           (DEFAULT_SCHEMA_VALIDATION ? "on" : "off"));
-        System.err.println("  Schema full checking:     " +
-                           (DEFAULT_SCHEMA_FULL_CHECKING ? "on" : "off"));
-
-    } // printUsage()
 
 } // class Test


### PR DESCRIPTION
Convert the dom.rename.Test test harness from a main()-driven to JUnit 3.
- Extends TestCase
- Replaces broken Assertion.verify/Assertion.equals calls with proper JUnit assertions
- Removed command-line arg processing, keeps hardcoded defaults
- Registered in batchtest in build.xml