### PR TITLE
Convert dom.ids.Test to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="dom/ids/Test.class"/>
            </fileset>
          </batchtest>
 
@@ -919,12 +920,6 @@ Authors:
           classpathref="test.classpath"
           failOnError="yes">
       <arg value="all"/>
-    </java>
-    <echo message="Running dom.ids.Test..." />
-    <java fork="yes"
-          classname="dom.ids.Test"
-          classpathref="test.classpath"
-          failOnError="yes">
     </java>
 <!--  
      TODO fix this test

--- a/tests/dom/ids/Test.java
+++ b/tests/dom/ids/Test.java
@@ -17,15 +17,14 @@
 
 package dom.ids;
 
+import junit.framework.TestCase;
+
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import dom.ParserWrapper;
-import dom.util.Assertion;
 
 /**
  * A simple program to test Document.getElementById() and the management
@@ -37,7 +36,7 @@ import dom.util.Assertion;
  *
  * @version $Id$
  */
-public class Test {
+public class Test extends TestCase {
 
     //
     // Constants
@@ -79,280 +78,92 @@ public class Test {
     // Public methods
     //
 
-    /** Performs the actual test. */
-    public void test(Document doc) {
+    public void testGetElementById() throws Exception {
 
-        System.out.println("DOM IDs Test...");
+        ParserWrapper parser = (ParserWrapper)
+            Class.forName(DEFAULT_PARSER_NAME).newInstance();
+
+        parser.setFeature(NAMESPACES_FEATURE_ID, DEFAULT_NAMESPACES);
+        parser.setFeature(VALIDATION_FEATURE_ID, DEFAULT_VALIDATION);
+        parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID, DEFAULT_SCHEMA_VALIDATION);
+        parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID, DEFAULT_SCHEMA_FULL_CHECKING);
+
+        if (parser instanceof dom.wrappers.Xerces) {
+            parser.setFeature(DEFERRED_DOM_FEATURE_ID, DEFAULT_DEFERRED_DOM);
+        }
+
+        Document doc = null;
+        try {
+            doc = parser.parse("tests/dom/ids/input.xml");
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
         Element el = doc.getElementById("one.worker");
-        Assertion.verify(el != null);
+        assertNotNull("el != null", el);
         Element el2 = doc.getElementById("one.worker there");
-        Assertion.verify(el2 == null);
+        assertNull("el2 == null", el2);
 
         if (el != null) {
-            Assertion.equals(el.getAttribute("id"), "one.worker");
+            assertEquals("el.getAttribute(\"id\")", "one.worker", el.getAttribute("id"));
             el.setAttribute("id", "my.worker");
             el2 = doc.getElementById("my.worker");
-            Assertion.verify(el2 == el);
-            
+            assertSame("el2 == el", el2, el);
+
             el2 = doc.getElementById("one.worker");
-            Assertion.verify(el2 == null);
+            assertNull("el2 == null", el2);
             el.removeAttribute("id");
             el2 = doc.getElementById("my.worker");
-            Assertion.verify(el2 == null);
+            assertNull("el2 == null", el2);
         }
 
         // find default id attribute and check its value
         NodeList elementList = doc.getElementsByTagName("person");
         Element testEmployee = (Element)elementList.item(1);
         Attr id = testEmployee.getAttributeNode("id2");
-        Assertion.verify(id.getNodeValue().equals("id02"), "value == 'id02'");
-
+        assertEquals("value == 'id02'", "id02", id.getNodeValue());
 
         Element elem = doc.getElementById("id02");
-        Assertion.verify(elem.getNodeName().equals("person"), "return by id 'id02'");
-        
-        // 
+        assertEquals("return by id 'id02'", "person", elem.getNodeName());
+
         // remove default attribute and check on retrieval what its value
         Attr removedAttr = testEmployee.removeAttributeNode(id);
         String value = testEmployee.getAttribute("id2");
-        Assertion.verify(value.equals("default.id"), "value='default.id'");
-
+        assertEquals("value='default.id'", "default.id", value);
 
         elem = doc.getElementById("default.id");
-        Assertion.verify(elem !=null, "elem by id 'default.id'");
-
+        assertNotNull("elem by id 'default.id'", elem);
 
         elem = doc.getElementById("id02");
-        Assertion.verify(elem ==null, "elem by id '02'");
-        
+        assertNull("elem by id '02'", elem);
+
         Element person = (Element)doc.getElementsByTagNameNS(null, "person").item(0);
         person.removeAttribute("id");
         person.removeAttribute("id2");
         person.setAttributeNS(null, "idAttr", "eb0009");
         person.setIdAttribute("idAttr", true);
-        
+
         elem = doc.getElementById("eb0009");
-        Assertion.verify(elem !=null, "elem by id 'eb0009'");
-       
+        assertNotNull("elem by id 'eb0009'", elem);
+
         doc.getDocumentElement().removeChild(person);
         elem = doc.getElementById("eb0009");
-        Assertion.verify(elem ==null, "element with id 'eb0009 removed'");
+        assertNull("element with id 'eb0009 removed'", elem);
 
         doc.getDocumentElement().appendChild(person);
         elem = doc.getElementById("eb0009");
-        Assertion.verify(elem !=null, "elem by id 'eb0009'");
+        assertNotNull("elem by id 'eb0009'", elem);
         Attr attr = (Attr)person.getAttributeNode("idAttr");
-        Assertion.verify(attr.isId(), "attribute is id");
+        assertTrue("attribute is id", attr.isId());
 
         person.setIdAttribute("idAttr", false);
         elem = doc.getElementById("eb0009");
-        Assertion.verify(elem ==null, "element with id 'eb0009 removed'");
-        
-        Assertion.verify(!attr.isId(), "attribute is not id");        
+        assertNull("element with id 'eb0009 removed'", elem);
 
-        System.out.println("done.");
+        assertFalse("attribute is not id", attr.isId());
 
-    } // test(Document)
-
-    //
-    // MAIN
-    //
-
-    /** Main program entry point. */
-    public static void main(String argv[]) {
-
-        // is there anything to do?
-        /*if (argv.length == 0) {
-            printUsage();
-            System.exit(1);
-        } */
-
-        
-        // variables
-        Test test = new Test();
-        ParserWrapper parser = null;
-        boolean namespaces = DEFAULT_NAMESPACES;
-        boolean validation = DEFAULT_VALIDATION;
-        boolean schemaValidation = DEFAULT_SCHEMA_VALIDATION;
-        boolean schemaFullChecking = DEFAULT_SCHEMA_FULL_CHECKING;
-        boolean deferredDom = DEFAULT_DEFERRED_DOM;
-        
-        String inputfile="tests/dom/ids/input.xml";
-        
-        // process arguments
-        for (int i = 0; i < argv.length; i++) {
-            String arg = argv[i];
-            if (arg.startsWith("-")) {
-                String option = arg.substring(1);
-                if (option.equals("p")) {
-                    // get parser name
-                    if (++i == argv.length) {
-                        System.err.println("error: Missing argument to -p"
-                                           + " option.");
-                    }
-                    String parserName = argv[i];
-
-                    // create parser
-                    try {
-                        parser = (ParserWrapper)
-                            Class.forName(parserName).newInstance();
-                    }
-                    catch (Exception e) {
-                        parser = null;
-                        System.err.println("error: Unable to instantiate "
-                                           + "parser (" + parserName + ")");
-                    }
-                    continue;
-                }
-                if (option.equalsIgnoreCase("n")) {
-                    namespaces = option.equals("n");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("v")) {
-                    validation = option.equals("v");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("s")) {
-                    schemaValidation = option.equals("s");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("f")) {
-                    schemaFullChecking = option.equals("f");
-                    continue;
-                }
-                if (option.equalsIgnoreCase("d")) {
-                    deferredDom = option.equals("d");
-                    continue;
-                }
-                if (option.equals("h")) {
-                    printUsage();
-                    continue;
-                }
-            }
-        }
-
-            // use default parser?
-            if (parser == null) {
-
-                // create parser
-                try {
-                    parser = (ParserWrapper)
-                        Class.forName(DEFAULT_PARSER_NAME).newInstance();
-                }
-                catch (Exception e) {
-                    System.err.println("error: Unable to instantiate parser ("
-                                       + DEFAULT_PARSER_NAME + ")");
-                    System.exit(1);
-                }
-            }
-
-            // set parser features
-            try {
-                parser.setFeature(NAMESPACES_FEATURE_ID, namespaces);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + NAMESPACES_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(VALIDATION_FEATURE_ID, validation);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + VALIDATION_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID,
-                                  schemaValidation);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + SCHEMA_VALIDATION_FEATURE_ID + ")");
-            }
-            try {
-                parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID,
-                                  schemaFullChecking);
-            }
-            catch (SAXException e) {
-                System.err.println("warning: Parser does not support feature ("
-                                   + SCHEMA_FULL_CHECKING_FEATURE_ID + ")");
-            }
-
-            if (parser instanceof dom.wrappers.Xerces) {
-                try {
-                    parser.setFeature(DEFERRED_DOM_FEATURE_ID,
-                                      deferredDom);
-                }
-                catch (SAXException e) {
-                    System.err.println("warning: Parser does not support " +
-                                       "feature (" +
-                                       DEFERRED_DOM_FEATURE_ID + ")");
-                }
-            }
-
-            // parse file
-            try {
-                Document document = null;
-                document = parser.parse(inputfile);
-                test.test(document);
-            }
-            catch (SAXParseException e) {
-                // ignore
-            }
-            catch (Exception e) {
-                System.err.println("error: Parse error occurred - " +
-                                   e.getMessage());
-                Exception se = e;
-                if (e instanceof SAXException) {
-                    se = ((SAXException)e).getException();
-                }
-                if (se != null)
-                  se.printStackTrace(System.err);
-                else
-                  e.printStackTrace(System.err);
-            }
-        
-
-    } // main(String[])
-
-    //
-    // Private static methods
-    //
-
-    /** Prints the usage. */
-    private static void printUsage() {
-
-        System.err.println("usage: java dom.ids.Test (options) " +
-                           "...data/personal.xml");
-        System.err.println();
-
-        System.err.println("options:");
-        System.err.println("  -p name    Select parser by name.");
-        System.err.println("  -d  | -D   Turn on/off (Xerces) deferred DOM.");
-        System.err.println("  -n  | -N   Turn on/off namespace processing.");
-        System.err.println("  -v  | -V   Turn on/off validation.");
-        System.err.println("  -s  | -S   Turn on/off Schema validation " +
-                           "support.");
-        System.err.println("             NOTE: Not supported by all parsers.");
-        System.err.println("  -f  | -F   Turn on/off Schema full checking.");
-        System.err.println("             NOTE: Requires use of -s and not " +
-                           "supported by all parsers.");
-        System.err.println("  -h         This help screen.");
-        System.err.println();
-
-        System.err.println("defaults:");
-        System.err.println("  Parser:     " + DEFAULT_PARSER_NAME);
-        System.err.println("  Xerces Deferred DOM: " +
-                           (DEFAULT_DEFERRED_DOM ? "on" : "off"));
-        System.err.println("  Namespaces: " +
-                           (DEFAULT_NAMESPACES ? "on" : "off"));
-        System.err.println("  Validation: " +
-                           (DEFAULT_VALIDATION ? "on" : "off"));
-        System.err.println("  Schema:     " +
-                           (DEFAULT_SCHEMA_VALIDATION ? "on" : "off"));
-        System.err.println("  Schema full checking:     " +
-                           (DEFAULT_SCHEMA_FULL_CHECKING ? "on" : "off"));
-
-    } // printUsage()
+    }
 
 } // class Test


### PR DESCRIPTION
Convert the dom.ids.Test test harness from a main()-driven to JUnit 3.\

- Extends TestCase
- Replaces broken Assertion.verify/Assertion.equals with proper JUnit assertions
- Registered in batchtest and old java task removed in build.xml