### PR TITLE
Convert dom.serialization.Test to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="dom/serialization/Test.class"/>
            </fileset>
          </batchtest>
 
@@ -931,13 +932,6 @@ Authors:
      [java] error: Error occurred - Feature 'http://apache.org/xml/features/validation/schema' is not recognized.
      [java] org.xml.sax.SAXNotRecognizedException: Feature 'http://apache.org/xml/features/validation/schema' is not recognized.
 -->
-    <echo message="Running dom.serialization.Test..." />
-    <java classname="dom.serialization.Test"
-          classpathref="test.classpath"
-          failOnError="yes">
-        <arg value="${data.dir}/personal-schema.xml"/>
-        <arg value="out.xml"/>
-    </java>
     
     <echo message="Running schema.Test..." />
     <java fork="yes"

--- a/tests/dom/serialization/Test.java
+++ b/tests/dom/serialization/Test.java
@@ -17,87 +17,53 @@
 
 package dom.serialization;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import junit.framework.TestCase;
+
 import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
+import org.w3c.dom.Element;
+import org.w3c.dom.Text;
 
-import dom.ParserWrapper;
+import org.apache.xerces.dom.DocumentImpl;
 
-/**
- * A java serialization test. This sample program parses a
- * document, then serializes out to a file, then reloads
- * it from the file.  The intent is to have zero exceptions
- * in the process.
- *
- * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
- * @version $Id$
- */
-public class Test {
+public class Test extends TestCase {
 
-    protected static final String NAMESPACES_FEATURE_ID = "http://xml.org/sax/features/namespaces";
+    public void testSerializationRoundTrip() throws Exception {
+        DocumentImpl doc = new DocumentImpl();
+        Element root = doc.createElement("root");
+        doc.appendChild(root);
+        root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:foo", "boo");
+        Text text = doc.createTextNode("hello");
+        root.appendChild(text);
 
-    protected static final String DEFAULT_PARSER_NAME = "dom.wrappers.Xerces";
-
-    public static void main(String args[]) {
-
-        if (args.length != 2) {
-            System.out.println("Usage: dom.serialization.Test input.xml output.xml");
-            System.exit(1);
-        }
-
-        ParserWrapper parser = null;
-
+        File serFile = File.createTempFile("xerces", ".ser");
+        serFile.deleteOnExit();
         try {
-            parser = (ParserWrapper) Class.forName(DEFAULT_PARSER_NAME).newInstance();
-        } catch (Exception e) {
-            System.err.println("error: Unable to instantiate parser (" + DEFAULT_PARSER_NAME + ")");
+            serialize(doc, serFile.getAbsolutePath());
+            Document newDocument = deserialize(serFile.getAbsolutePath());
+            assertNotNull(newDocument);
+            Element newRoot = newDocument.getDocumentElement();
+            assertNotNull(newRoot);
+            assertEquals("root", newRoot.getNodeName());
+            assertEquals("boo", newRoot.getAttributeNS("http://www.w3.org/2000/xmlns/", "foo"));
+            assertEquals("hello", newRoot.getFirstChild().getNodeValue());
+        } finally {
+            serFile.delete();
         }
-
-        try {
-            parser.setFeature(NAMESPACES_FEATURE_ID, true);
-        } catch (SAXException e) {
-            System.err.println("warning: Parser does not support feature (" + NAMESPACES_FEATURE_ID + ")");
-        }
-
-        try {
-            Document document = null;
-            parser.setFeature("http://xml.org/sax/features/validation", true);
-            parser.setFeature("http://apache.org/xml/features/validation/schema", true);
-            document = parser.parse(args[0]);
-            document.getDocumentElement().setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:foo", "boo");
-            serialize(document, args[1]);
-            Document newDocument = deserialize(args[1]);
-            Document emptyDoc = new org.apache.xerces.dom.DocumentImpl();
-            emptyDoc.importNode(newDocument.getDocumentElement(), true);
-
-            System.out.println("done.");
-        } catch (Exception e) {
-            System.err.println("error: Error occurred - " + e.getMessage());
-            Exception se = e;
-            if (e instanceof SAXException) {
-                se = ((SAXException) e).getException();
-            }
-            if (se != null)
-                se.printStackTrace(System.err);
-            else
-                e.printStackTrace(System.err);
-        }
-
     }
 
     public static void serialize(Document document, String filename) throws Exception {
-        System.out.println("Serializing parsed document");
         ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(filename));
         out.writeObject(document);
         out.close();
     }
 
     public static Document deserialize(String filename) throws Exception {
-        System.out.println("De-Serializing parsed document");
         ObjectInputStream in = new ObjectInputStream(new FileInputStream(filename));
         Document result = (Document) in.readObject();
         return result;

--- a/tests/dom/serialization/Test.java
+++ b/tests/dom/serialization/Test.java
@@ -35,7 +35,7 @@ public class Test extends TestCase {
 
     public void testSerializationRoundTrip() throws Exception {
         DocumentImpl doc = new DocumentImpl();
-        Element root = doc.createElement("root");
+        Element root = doc.createElementNS(null, "root");
         doc.appendChild(root);
         root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:foo", "boo");
         Text text = doc.createTextNode("hello");


### PR DESCRIPTION
Convert the dom.serialization.Test test harness from main()-driven to JUnit 3.
- Extends TestCase
- Creates in-memory document, round-trips through Java serialization, verifies contents
- Registered in batchtest and old java task removed in build.xml