### PR TITLE
Convert jaxp.PropertyTest to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="jaxp/PropertyTest.class"/>
            </fileset>
          </batchtest>
 
@@ -942,12 +943,6 @@ Authors:
     <echo message="Running schema.Test..." />
     <java fork="yes"
           classname="schema.Test"
-          classpathref="test.classpath"
-          failOnError="yes">
-    </java>
-    <echo message="Running jaxp.PropertyTest..." />
-    <java fork="yes"
-          classname="jaxp.PropertyTest"
           classpathref="test.classpath"
           failOnError="yes">
     </java>

--- a/tests/jaxp/PropertyTest.java
+++ b/tests/jaxp/PropertyTest.java
@@ -20,103 +20,53 @@ package jaxp;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
-/**
- * This sample program tests JAXP 1.2 properties
- */
-public class PropertyTest extends DefaultHandler{
+import junit.framework.TestCase;
 
-	public static void main(String[] argv) {
+public class PropertyTest extends TestCase {
 
-		try {
-			SAXParserFactory spf = SAXParserFactory.newInstance();
-			spf.setValidating(true);
-			spf.setNamespaceAware(true);
-			SAXParser parser = spf.newSAXParser();
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaLanguage",
-				"http://www.w3.org/2001/XMLSchema");
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaSource",
-				new String[] { "personal.xsd", "ipo.xsd" });
-			parser.parse("tests/jaxp/data/personal-schema.xml", new PropertyTest());
+    public void testSchemaProperties() throws Exception {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setValidating(true);
+        spf.setNamespaceAware(true);
+        SAXParser parser = spf.newSAXParser();
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
+            "http://www.w3.org/2001/XMLSchema");
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaSource",
+            new String[] { "personal.xsd", "ipo.xsd" });
+        parser.parse("tests/jaxp/data/personal-schema.xml", new DefaultHandler());
 
-			parser = spf.newSAXParser();
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaLanguage",
-				"http://www.w3.org/2001/XMLSchema");
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaSource",
-				new String[] { "address.xsd", "ipo.xsd", });
+        // Second parse should fail
+        parser = spf.newSAXParser();
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
+            "http://www.w3.org/2001/XMLSchema");
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaSource",
+            new String[] { "address.xsd", "ipo.xsd" });
+        try {
+            parser.parse("tests/jaxp/data/personal-schema.xml", new DefaultHandler());
+            fail("Should have thrown exception for address.xsd, ipo.xsd");
+        } catch (Exception e) {
+            // expected
+        }
 
-			try {
-				parser.parse("tests/jaxp/data/personal-schema.xml", new PropertyTest());
-				System.err.println("ERROR!");
-			} catch (Exception e) {
-			}
-			
-			parser = spf.newSAXParser();
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaLanguage",
-				"http://www.w3.org/2001/XMLSchema");
-			parser.setProperty(
-				"http://java.sun.com/xml/jaxp/properties/schemaSource",
-				new String[] { "personal.xsd", "ipo.xsd", "a.xsd"});
-
-			try {
-				parser.parse("tests/jaxp/data/personal-schema.xml", new PropertyTest());
-				System.err.println("ERROR!");
-			} catch (Exception e) {
-			}
-			
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-		System.out.println("done.");
-	}
-	
-	/** Warning. */
-	public void warning(SAXParseException ex) throws SAXException {
-		printError("Warning", ex);
-	} // warning(SAXParseException)
-
-	/** Error. */
-	public void error(SAXParseException ex) throws SAXException {
-		printError("Error", ex);
-	} // error(SAXParseException)
-
-	/** Fatal error. */
-	public void fatalError(SAXParseException ex) throws SAXException {
-		printError("Fatal Error", ex);
-		throw ex;
-	} // fatalError(SAXParseException)
-
-
-	protected void printError(String type, SAXParseException ex) {
-
-		System.err.print("[");
-		System.err.print(type);
-		System.err.print("] ");
-		String systemId = ex.getSystemId();
-		if (systemId != null) {
-			int index = systemId.lastIndexOf('/');
-			if (index != -1)
-				systemId = systemId.substring(index + 1);
-			System.err.print(systemId);
-		}
-		System.err.print(':');
-		System.err.print(ex.getLineNumber());
-		System.err.print(':');
-		System.err.print(ex.getColumnNumber());
-		System.err.print(": ");
-		System.err.print(ex.getMessage());
-		System.err.println();
-		System.err.flush();
-
-	} // printError(String,SAXParseException)
-
-
+        // Third parse should fail
+        parser = spf.newSAXParser();
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
+            "http://www.w3.org/2001/XMLSchema");
+        parser.setProperty(
+            "http://java.sun.com/xml/jaxp/properties/schemaSource",
+            new String[] { "personal.xsd", "ipo.xsd", "a.xsd" });
+        try {
+            parser.parse("tests/jaxp/data/personal-schema.xml", new DefaultHandler());
+            fail("Should have thrown exception for personal.xsd, ipo.xsd, a.xsd");
+        } catch (Exception e) {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
Convert the jaxp.PropertyTest test harness from main()-driven to JUnit 3.

- Extends TestCase (removed DefaultHandler inheritance)
- Tests schema property configuration with expected failures
- Registered in batchtest and old java task removed in build.xml