### PR TITLE
Convert jaxp.JAXPSpecTest to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="jaxp/JAXPSpecTest.class"/>
            </fileset>
          </batchtest>
 
@@ -950,16 +951,6 @@ Authors:
           classname="jaxp.PropertyTest"
           classpathref="test.classpath"
           failOnError="yes">
-    </java>
-    <echo message="Running jaxp.JAXPSpecTest..." />
-    <java fork="yes"
-          classname="jaxp.JAXPSpecTest"
-          classpathref="test.classpath"
-          failOnError="yes">
-        <arg value="testSchemaLanguageSAX"/>
-        <arg value="testSchemaSourceSAX"/>
-        <arg value="testSchemaLanguageDOM"/>
-        <arg value="testSchemaSourceDOM"/>
     </java>
     <echo message="Running xinclude.Test..." />
     <java fork="yes"

--- a/tests/jaxp/JAXPSpecTest.java
+++ b/tests/jaxp/JAXPSpecTest.java
@@ -24,10 +24,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import junit.framework.TestCase;
+
 import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /** 
@@ -44,34 +44,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * 
  * @version $Id$
  */
-public class JAXPSpecTest extends DefaultHandler {
-    
-    /** TestCase Main.
-     * @param args
-     * @throws Exception
-     */
-    public static void main(String[] args) throws Exception {
-        
-        JAXPSpecTest jaxpTest = new JAXPSpecTest();
-        
-        if (args.length == 0) {
-            JAXPSpecTest.printUsage();
-        }
-        for (int i = 0; i < args.length; i++) {
-            String arg = args[i];
-            if(arg.equals("testSchemaLanguageSAX"))
-                jaxpTest.testSchemaLanguageSAX();
-            else if(arg.equals("testSchemaSourceSAX"))
-                jaxpTest.testSchemaSourceSAX();
-            else if(arg.equals("testSchemaLanguageDOM"))
-                jaxpTest.testSchemaLanguageDOM();
-            else if(arg.equals("testSchemaSourceDOM"))
-                jaxpTest.testSchemaSourceDOM();
-            else
-                JAXPSpecTest.printUsage();
-        }
-        
-    }
+public class JAXPSpecTest extends TestCase {
     
     /** 
      * Schema Language property should be ignored if
@@ -80,17 +53,13 @@ public class JAXPSpecTest extends DefaultHandler {
      */
     
     public void testSchemaLanguageSAX() throws Exception{
-        
-        System.out.println(" Running JAXPSpecTest.testSchemaLanguageSAX ");
         SAXParserFactory spf = SAXParserFactory.newInstance();
         spf.setValidating(false);
         SAXParser saxParser = spf.newSAXParser();
-        //Schema Language Property should be ignored since validation is set to false.
         saxParser.setProperty(
         "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
         "http://www.w3.org/2001/XMLSchema");
-        saxParser.parse("tests/jaxp/data/personal-schema.xml",this);
-        System.out.println(" JAXPSpecTest.testSchemaLanguageSAX Passed ");
+        saxParser.parse("tests/jaxp/data/personal-schema.xml", new DefaultHandler());
     }
     
     /** SAXParser should throw SAXNotSupportedException when SchemaSource property is
@@ -99,19 +68,17 @@ public class JAXPSpecTest extends DefaultHandler {
      */
     
     public void testSchemaSourceSAX() throws Exception{
-        try{
-            System.out.println(" Running JAXPSpecTest.testSchemaSourceSAX ");
+        try {
             SAXParserFactory spf = SAXParserFactory.newInstance();
             spf.setValidating(true);
             SAXParser saxParser = spf.newSAXParser();
-            //Schema Language property should be set before setting schema source property.
-            //setting this property should throw SAXNotSupportedException
             saxParser.setProperty(
             "http://java.sun.com/xml/jaxp/properties/schemaSource",
             "tests/jaxp/data/personal-schema.xsd");
-            saxParser.parse("tests/jaxp/data/personal-schema.xml",this);
-        }catch(SAXNotSupportedException ne){
-            System.out.println(" JAXPSpecTest.testSchemaSourceSAX Passed");
+            saxParser.parse("tests/jaxp/data/personal-schema.xml", new DefaultHandler());
+            fail("Should have thrown SAXNotSupportedException");
+        } catch (SAXNotSupportedException e) {
+            // expected
         }
     }
     
@@ -120,20 +87,15 @@ public class JAXPSpecTest extends DefaultHandler {
      * @throws Exception  */
     
     public void testSchemaLanguageDOM() throws Exception {
-        
-        System.out.println(" Running JAXPSpecTest.testSchemaLanguageDOM ");
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setValidating(false);
-        //Schema Language Property should be ignored since validation is set to false.
         dbf.setAttribute(
         "http://java.sun.com/xml/jaxp/properties/schemaLanguage",
         "http://www.w3.org/2001/XMLSchema");
         DocumentBuilder docBuilder = dbf.newDocumentBuilder();
-        docBuilder.setErrorHandler(this);
+        docBuilder.setErrorHandler(new DefaultHandler());
         Document document = docBuilder.parse(
         new File("tests/jaxp/data/personal-schema.xml"));
-        System.out.println(" JAXPSpecTest.testSchemaLanguageDOM Passed");
-        
     }
     
     /** DOMParser should throw IllegalArgumentException when SchemaSource property is
@@ -142,85 +104,20 @@ public class JAXPSpecTest extends DefaultHandler {
      */
     
     public void testSchemaSourceDOM() throws Exception {
-        try{
-            System.out.println(" Running JAXPSpecTest.testSchemaSourceDOM ");
+        try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setValidating(true);
-            //Schema Language property should be set before setting schema source property.
-            //setting this property should throw IllegalArgumentException
             dbf.setAttribute(
             "http://java.sun.com/xml/jaxp/properties/schemaSource",
             "tests/jaxp/data/personal-schema.xsd");
             DocumentBuilder docBuilder = dbf.newDocumentBuilder();
-            docBuilder.setErrorHandler(this);
+            docBuilder.setErrorHandler(new DefaultHandler());
             Document document = docBuilder.parse(
             "tests/jaxp/data/personal-schema.xml");
+            fail("Should have thrown IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            System.out.println(" JAXPSpecTest.testSchemaSourceDOM Passed");
+            // expected
         }
-        
     }
-    
-    
-    /** Handles Warnings
-     * @param ex
-     * @throws SAXException
-     */
-    public void warning(SAXParseException ex) throws SAXException {
-        printError("Warning", ex);
-    }
-    
-    /** Handles Errors.
-     * @param ex
-     * @throws SAXException
-     */
-    
-    public void error(SAXParseException ex) throws SAXException {
-        printError("Error", ex);
-    }
-    
-    /** Handles Fatal errors.
-     * @param ex
-     * @throws SAXException
-     */
-    
-    public void fatalError(SAXParseException ex) throws SAXException {
-        printError("Fatal Error", ex);
-        throw ex;
-    }
-    
-    
-    /**
-     * @param type
-     * @param ex
-     */
-    private void printError(String type, SAXParseException ex) {
-        
-        System.err.print("[");
-        System.err.print(type);
-        System.err.print("] ");
-        String systemId = ex.getSystemId();
-        if (systemId != null) {
-            int index = systemId.lastIndexOf('/');
-            if (index != -1)
-                systemId = systemId.substring(index + 1);
-            System.err.print(systemId);
-        }
-        System.err.print(':');
-        System.err.print(ex.getLineNumber());
-        System.err.print(':');
-        System.err.print(ex.getColumnNumber());
-        System.err.print(": ");
-        System.err.print(ex.getMessage());
-        System.err.println();
-        System.err.flush();
-        
-    }
-    
-    private static void printUsage(){
-        System.err.println("Usage : JAXPSpecTest testSchemaLanguageSAX testSchemaSourceSAX testSchemaLanguageDOM testSchemaSourceDOM  ... ");
-    }
-    
-    
 }
 


### PR DESCRIPTION
Convert the jaxp.JAXPSpecTest test harness from main()-driven to JUnit 3.
- Extends TestCase (removed DefaultHandler inheritance)
- Existing test methods become proper JUnit tests
- Registered in batchtest and old java task removed in build.xml