### PR TITLE
Convert schema.Test to JUnit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -845,6 +845,7 @@ Authors:
              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
             -->             
+             <include name="schema/Test.class"/>
            </fileset>
          </batchtest>
 
@@ -939,12 +940,6 @@ Authors:
         <arg value="out.xml"/>
     </java>
     
-    <echo message="Running schema.Test..." />
-    <java fork="yes"
-          classname="schema.Test"
-          classpathref="test.classpath"
-          failOnError="yes">
-    </java>
     <echo message="Running jaxp.PropertyTest..." />
     <java fork="yes"
           classname="jaxp.PropertyTest"

--- a/tests/schema/Test.java
+++ b/tests/schema/Test.java
@@ -17,9 +17,8 @@
 
 package schema;
 
+import junit.framework.TestCase;
 import org.apache.xerces.parsers.SAXParser;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -27,125 +26,41 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * @author Khaled Noaman, IBM
  */
-public class Test extends DefaultHandler {
-
+public class Test extends TestCase {
 
     // feature ids
-
-    /** Namespaces feature id (http://xml.org/sax/features/namespaces). */
     protected static final String NAMESPACES_FEATURE_ID = "http://xml.org/sax/features/namespaces";
-
-    /** Namespace prefixes feature id (http://xml.org/sax/features/namespace-prefixes). */
     protected static final String NAMESPACE_PREFIXES_FEATURE_ID = "http://xml.org/sax/features/namespace-prefixes";
-
-    /** Validation feature id (http://xml.org/sax/features/validation). */
     protected static final String VALIDATION_FEATURE_ID = "http://xml.org/sax/features/validation";
-
-    /** Schema validation feature id (http://apache.org/xml/features/validation/schema). */
     protected static final String SCHEMA_VALIDATION_FEATURE_ID = "http://apache.org/xml/features/validation/schema";
-
-    /** Schema full checking feature id (http://apache.org/xml/features/validation/schema-full-checking). */
     protected static final String SCHEMA_FULL_CHECKING_FEATURE_ID = "http://apache.org/xml/features/validation/schema-full-checking";
-
-    /** Dynamic validation feature id (http://apache.org/xml/features/validation/dynamic). */
     protected static final String DYNAMIC_VALIDATION_FEATURE_ID = "http://apache.org/xml/features/validation/dynamic";
 
-
     // property ids
-
-    /** schema noNamespaceSchemaLocation property id (http://apache.org/xml/properties/schema/external-noNamespaceSchemaLocation). */
     protected static final String SCHEMA_NONS_LOCATION_ID = "http://apache.org/xml/properties/schema/external-noNamespaceSchemaLocation";
-
 
     // Default data source location
     protected static final String SOURCE_LOC_ID = "./tests/schema/";
 
-
-    // Default constructor
-    public Test() {
-    }
-
-
-    // ErrorHandler methods
-
-    public void warning(SAXParseException ex) throws SAXException {
-        printError("Warning", ex);
-    }
-
-    public void error(SAXParseException ex) throws SAXException {
-        printError("Error", ex);
-    }
-
-    public void fatalError(SAXParseException ex) throws SAXException {
-        printError("Fatal Error", ex);
-    }
-
-
-    // Protected methods
-    protected void printError(String type, SAXParseException ex) {
-
-        System.err.print("[");
-        System.err.print(type);
-        System.err.print("] ");
-        if (ex== null) {
-            System.out.println("!!!");
-        }
-        String systemId = ex.getSystemId();
-        if (systemId != null) {
-            int index = systemId.lastIndexOf('/');
-            if (index != -1)
-                systemId = systemId.substring(index + 1);
-            System.err.print(systemId);
-        }
-        System.err.print(':');
-        System.err.print(ex.getLineNumber());
-        System.err.print(':');
-        System.err.print(ex.getColumnNumber());
-        System.err.print(": ");
-        System.err.print(ex.getMessage());
-        System.err.println();
-        System.err.flush();
+    public Test(String name) {
+        super(name);
     }
 
     public void testSettingNoNamespaceSchemaLocation() throws Exception {
+        SAXParser parser = new org.apache.xerces.parsers.SAXParser();
 
-        System.err.println("#");
-        System.err.println("# Testing Setting noNamespaceSchemaLocation property");
-        System.err.println("#");
+        parser.setFeature(NAMESPACES_FEATURE_ID, true);
+        parser.setFeature(NAMESPACE_PREFIXES_FEATURE_ID, false);
+        parser.setFeature(VALIDATION_FEATURE_ID, true);
+        parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID, true);
+        parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID, false);
+        parser.setFeature(DYNAMIC_VALIDATION_FEATURE_ID, false);
 
-        try {
-            SAXParser parser = new org.apache.xerces.parsers.SAXParser();
+        parser.setProperty(SCHEMA_NONS_LOCATION_ID, "personal.xsd");
 
-            // Set features
-            parser.setFeature(NAMESPACES_FEATURE_ID, true);
-            parser.setFeature(NAMESPACE_PREFIXES_FEATURE_ID, false);
-            parser.setFeature(VALIDATION_FEATURE_ID, true);
-            parser.setFeature(SCHEMA_VALIDATION_FEATURE_ID, true);
-            parser.setFeature(SCHEMA_FULL_CHECKING_FEATURE_ID, false);
-            parser.setFeature(DYNAMIC_VALIDATION_FEATURE_ID, false);
+        parser.setContentHandler(new DefaultHandler());
+        parser.setErrorHandler(new DefaultHandler());
 
-            // Set properties
-            parser.setProperty(SCHEMA_NONS_LOCATION_ID, "personal.xsd");
-
-            // Set handlers
-            parser.setContentHandler(this);
-            parser.setErrorHandler(this);
-
-            // parse document
-            parser.parse(SOURCE_LOC_ID + "personal-schema.xml");
-            System.err.println("Pass: " + SOURCE_LOC_ID + "personal-schema.xml");
-            System.err.println();
-        }
-        catch (SAXException e) {
-            System.err.println("Fail:" + e.getMessage());
-        }
-    }
-
-
-    /** Main program entry point. */
-    public static void main(String argv[]) throws Exception {
-
-        Test test = new Test();
-        test.testSettingNoNamespaceSchemaLocation();
+        parser.parse(SOURCE_LOC_ID + "personal-schema.xml");
     }
 }


### PR DESCRIPTION
Convert the schema.Test test harness from main()-driven to JUnit 3.

- Extends TestCase
- Tests schema validation with noNamespaceSchemaLocation
-  Registered in batchtest and old java task removed in build.xml