### PR TITLE
Fix UnparsedEntityCheckingTest: remove leftover RuntimeException

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -836,15 +836,15 @@ Authors:
              <include name="schema/config/IgnoreXSIType_C_A_Test.class"/>
              <include name="schema/config/RootSimpleTypeDefinitionTest.class"/>
              <include name="schema/config/RootTypeDefinitionTest.class"/>
-             <include name="schema/config/UseGrammarPoolOnly_False_Test.class"/>
-          <!-- These tests are failing. Fix them.
-             <include name="schema/config/IgnoreXSIType_C_AC_Test.class"/>
-             <include name="schema/config/IgnoreXSIType_C_CA_Test.class"/>
-             <include name="schema/config/IgnoreXSIType_C_C_Test.class"/>
-             <include name="schema/config/SurrogatePairLengthTest.class"/>
-             <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
-             <include name="schema/config/UnparsedEntityCheckingTest.class"/>
-            -->             
+              <include name="schema/config/UseGrammarPoolOnly_False_Test.class"/>
+              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
+           <!-- These tests are failing. Fix them.
+              <include name="schema/config/IgnoreXSIType_C_AC_Test.class"/>
+              <include name="schema/config/IgnoreXSIType_C_CA_Test.class"/>
+              <include name="schema/config/IgnoreXSIType_C_C_Test.class"/>
+              <include name="schema/config/SurrogatePairLengthTest.class"/>
+              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
+             -->
              <include name="jaxp/JAXPSpecTest.class"/>
              <include name="dom/ids/Test.class"/>
            </fileset>

--- a/tests/schema/config/UnparsedEntityCheckingTest.java
+++ b/tests/schema/config/UnparsedEntityCheckingTest.java
@@ -55,7 +55,6 @@ public class UnparsedEntityCheckingTest extends BaseTest {
         }
         
         checkDefault();
-        throw new RuntimeException();
     }
     
     public void testSetFalseValid() {

--- a/tests/schema/config/UnparsedEntityCheckingTest.java
+++ b/tests/schema/config/UnparsedEntityCheckingTest.java
@@ -17,11 +17,8 @@
 
 package schema.config;
 
-import junit.framework.Assert;
-
 import org.apache.xerces.dom.PSVIElementNSImpl;
 import org.apache.xerces.xs.ItemPSVI;
-import org.xml.sax.SAXException;
 
 /**
  * @author Peter McCracken, IBM
@@ -47,89 +44,43 @@ public class UnparsedEntityCheckingTest extends BaseTest {
         super(name);
     }
     
-    public void testDefaultValid() {
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+    public void testDefaultValid() throws Exception {
+        validateDocument();
         checkDefault();
     }
     
-    public void testSetFalseValid() {
-        try {
-            fValidator.setFeature(UNPARSED_ENTITY_CHECKING, false);
-        } catch (SAXException e) {
-            Assert.fail("Error setting feature.");
-        }
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+    public void testSetFalseValid() throws Exception {
+        fValidator.setFeature(UNPARSED_ENTITY_CHECKING, false);
+        validateDocument();
         checkDefault();
     }
     
-    public void testSetTrueValid() {
-        try {
-            fValidator.setFeature(UNPARSED_ENTITY_CHECKING, true);
-        } catch (SAXException e) {
-            Assert.fail("Error setting feature.");
-        }
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+    public void testSetTrueValid() throws Exception {
+        fValidator.setFeature(UNPARSED_ENTITY_CHECKING, true);
+        validateDocument();
         checkDefault();
     }
     
-    public void testDefaultInvalid() {
+    public void testDefaultInvalid() throws Exception {
         ((PSVIElementNSImpl) fRootNode).setAttributeNS(null,
                 "unparsedEntityAttr", "invalid");
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+        validateDocument();
         checkInvalid();
     }
     
-    public void testSetFalseInvalid() {
+    public void testSetFalseInvalid() throws Exception {
         ((PSVIElementNSImpl) fRootNode).setAttributeNS(null,
                 "unparsedEntityAttr", "invalid");
-        try {
-            fValidator.setFeature(UNPARSED_ENTITY_CHECKING, false);
-        } catch (SAXException e) {
-            Assert.fail("Error setting feature.");
-        }
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+        fValidator.setFeature(UNPARSED_ENTITY_CHECKING, false);
+        validateDocument();
         checkDefault();
     }
     
-    public void testSetTrueInvalid() {
+    public void testSetTrueInvalid() throws Exception {
         ((PSVIElementNSImpl) fRootNode).setAttributeNS(null,
                 "unparsedEntityAttr", "invalid");
-        try {
-            fValidator.setFeature(UNPARSED_ENTITY_CHECKING, true);
-        } catch (SAXException e) {
-            Assert.fail("Error setting feature.");
-        }
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+        fValidator.setFeature(UNPARSED_ENTITY_CHECKING, true);
+        validateDocument();
         checkInvalid();
     }
     


### PR DESCRIPTION
`testDefaultValid()` in `UnparsedEntityCheckingTest` had a leftover `throw new RuntimeException();` after `checkDefault()` at line 58, which caused the test to always fail with an error.

This was likely left over from development/debugging. Removed the throw statement so the test properly passes when validation succeeds.