### PR TITLE
Enable SurrogatePairLengthTest

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -860,6 +860,7 @@ Authors:
            errorproperty="test.failed"
            showoutput="yes">
         <classpath refid="test.classpath"/>
+        <sysproperty key="org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength" value="true"/>
         <test name="schema.config.SurrogatePairLengthTest" todir="test-reports"/>
         <formatter type="brief" usefile="false"/>
     </junit>

--- a/build.xml
+++ b/build.xml
@@ -844,18 +844,25 @@ Authors:
               <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
               <include name="schema/config/UnparsedEntityCheckingTest.class"/>
              -->
-              <!-- SurrogatePairLengthTest uses reflection to modify a private
-                   static field in TypeValidator. This test is NOT safe for
-                   parallel execution and must run sequentially.                -->
-              <include name="schema/config/SurrogatePairLengthTest.class"/>
-              <include name="schema/Test.class"/>
+               <include name="schema/Test.class"/>
               <include name="jaxp/JAXPSpecTest.class"/>
               <include name="dom/ids/Test.class"/>
             </fileset>
           </batchtest>
 
-        <formatter type="brief" usefile="false"/>
+         <formatter type="brief" usefile="false"/>
      </junit>
+
+    <junit fork="yes"
+           haltonfailure="no"
+           haltonerror="yes"
+           failureproperty="test.failed"
+           errorproperty="test.failed"
+           showoutput="yes">
+        <classpath refid="test.classpath"/>
+        <test name="schema.config.SurrogatePairLengthTest" todir="test-reports"/>
+        <formatter type="brief" usefile="false"/>
+    </junit>
     <fail if="test.failed" message="JUnit tests failed! Check the output above."/>
 
     <echo message="Performing sanity test for ${parser.Name} ${parser.Version} ..." />

--- a/build.xml
+++ b/build.xml
@@ -844,9 +844,9 @@ Authors:
               <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
               <include name="schema/config/UnparsedEntityCheckingTest.class"/>
              -->
-             <!-- SurrogatePairLengthTest sets a system property in setUp() that
-                  TypeValidator reads at runtime. Tests run sequentially within a
-                  shared JVM, so setUp/tearDown safely manage the property.        -->
+              <!-- SurrogatePairLengthTest uses reflection to modify a private
+                   static field in TypeValidator. This test is NOT safe for
+                   parallel execution and must run sequentially.                -->
               <include name="schema/config/SurrogatePairLengthTest.class"/>
               <include name="schema/Test.class"/>
               <include name="jaxp/JAXPSpecTest.class"/>

--- a/build.xml
+++ b/build.xml
@@ -837,21 +837,30 @@ Authors:
              <include name="schema/config/RootSimpleTypeDefinitionTest.class"/>
              <include name="schema/config/RootTypeDefinitionTest.class"/>
              <include name="schema/config/UseGrammarPoolOnly_False_Test.class"/>
-          <!-- These tests are failing. Fix them.
-             <include name="schema/config/IgnoreXSIType_C_AC_Test.class"/>
-             <include name="schema/config/IgnoreXSIType_C_CA_Test.class"/>
-             <include name="schema/config/IgnoreXSIType_C_C_Test.class"/>
-             <include name="schema/config/SurrogatePairLengthTest.class"/>
-             <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
-             <include name="schema/config/UnparsedEntityCheckingTest.class"/>
-            -->             
-             <include name="jaxp/JAXPSpecTest.class"/>
-             <include name="dom/ids/Test.class"/>
-           </fileset>
-         </batchtest>
+           <!-- These tests are failing. Fix them.
+              <include name="schema/config/IgnoreXSIType_C_AC_Test.class"/>
+              <include name="schema/config/IgnoreXSIType_C_CA_Test.class"/>
+              <include name="schema/config/IgnoreXSIType_C_C_Test.class"/>
+              <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
+              <include name="schema/config/UnparsedEntityCheckingTest.class"/>
+             -->             
+              <include name="jaxp/JAXPSpecTest.class"/>
+              <include name="dom/ids/Test.class"/>
+            </fileset>
+          </batchtest>
 
-         
-       <formatter type="brief" usefile="false"/>
+        <formatter type="brief" usefile="false"/>
+     </junit>
+
+    <junit fork="yes" forkmode="perTest"
+           haltonfailure="no"
+           haltonerror="yes"
+           failureproperty="test.failed"
+           errorproperty="test.failed"
+           showoutput="yes">
+        <classpath refid="test.classpath"/>
+        <test name="schema.config.SurrogatePairLengthTest" todir="test-reports"/>
+        <formatter type="brief" usefile="false"/>
     </junit>
     <fail if="test.failed" message="JUnit tests failed! Check the output above."/>
 

--- a/build.xml
+++ b/build.xml
@@ -844,6 +844,10 @@ Authors:
               <include name="schema/config/UseGrammarPoolOnly_True_Test.class"/>
               <include name="schema/config/UnparsedEntityCheckingTest.class"/>
              -->
+             <!-- SurrogatePairLengthTest sets a system property in setUp() that
+                  TypeValidator reads at runtime. Tests run sequentially within a
+                  shared JVM, so setUp/tearDown safely manage the property.        -->
+              <include name="schema/config/SurrogatePairLengthTest.class"/>
               <include name="schema/Test.class"/>
               <include name="jaxp/JAXPSpecTest.class"/>
               <include name="dom/ids/Test.class"/>
@@ -852,17 +856,6 @@ Authors:
 
         <formatter type="brief" usefile="false"/>
      </junit>
-
-    <junit fork="yes" forkmode="perTest"
-           haltonfailure="no"
-           haltonerror="yes"
-           failureproperty="test.failed"
-           errorproperty="test.failed"
-           showoutput="yes">
-        <classpath refid="test.classpath"/>
-        <test name="schema.config.SurrogatePairLengthTest" todir="test-reports"/>
-        <formatter type="brief" usefile="false"/>
-    </junit>
     <fail if="test.failed" message="JUnit tests failed! Check the output above."/>
 
     <echo message="Performing sanity test for ${parser.Name} ${parser.Version} ..." />

--- a/build.xml
+++ b/build.xml
@@ -860,7 +860,6 @@ Authors:
            errorproperty="test.failed"
            showoutput="yes">
         <classpath refid="test.classpath"/>
-        <sysproperty key="org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength" value="true"/>
         <test name="schema.config.SurrogatePairLengthTest" todir="test-reports"/>
         <formatter type="brief" usefile="false"/>
     </junit>

--- a/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
+++ b/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
@@ -39,15 +39,8 @@ import org.apache.xerces.util.XMLChar;
  */
 public abstract class TypeValidator {
     
-    private static final boolean USE_CODE_POINT_COUNT_FOR_STRING_LENGTH = AccessController.doPrivileged(new PrivilegedAction() {
-        @Override
-        public Object run() {
-            try {
-                return Boolean.getBoolean("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength") ? Boolean.TRUE : Boolean.FALSE;
-            }
-            catch (SecurityException ex) {}
-            return Boolean.FALSE;
-        }}) == Boolean.TRUE;
+    // Checked at runtime to allow tests to set the property via System.setProperty()
+    // before each test. Tests execute sequentially within a shared JVM.
 
     /**
      * Which facets are allowed for this type.
@@ -138,12 +131,18 @@ public abstract class TypeValidator {
     public int getDataLength(Object value) {
         if (value instanceof String) {
             final String str = (String)value;
-            if (!USE_CODE_POINT_COUNT_FOR_STRING_LENGTH) {
+            if (!getCodePointCountEnabled()) {
                 return str.length();
             }
             return getCodePointLength(str);
         }
         return -1;
+    }
+    
+    private static boolean getCodePointCountEnabled() {
+        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> 
+            Boolean.getBoolean("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength")
+        );
     }
 
     /**

--- a/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
+++ b/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
@@ -39,8 +39,15 @@ import org.apache.xerces.util.XMLChar;
  */
 public abstract class TypeValidator {
     
-    // Checked at runtime to allow tests to set the property via System.setProperty()
-    // before each test. Tests execute sequentially within a shared JVM.
+    private static boolean USE_CODE_POINT_COUNT_FOR_STRING_LENGTH = AccessController.doPrivileged(new PrivilegedAction() {
+        @Override
+        public Object run() {
+            try {
+                return Boolean.getBoolean("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength") ? Boolean.TRUE : Boolean.FALSE;
+            }
+            catch (SecurityException ex) {}
+            return Boolean.FALSE;
+        }}) == Boolean.TRUE;
 
     /**
      * Which facets are allowed for this type.
@@ -131,18 +138,12 @@ public abstract class TypeValidator {
     public int getDataLength(Object value) {
         if (value instanceof String) {
             final String str = (String)value;
-            if (!getCodePointCountEnabled()) {
+            if (!USE_CODE_POINT_COUNT_FOR_STRING_LENGTH) {
                 return str.length();
             }
             return getCodePointLength(str);
         }
         return -1;
-    }
-    
-    private static boolean getCodePointCountEnabled() {
-        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> 
-            Boolean.getBoolean("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength")
-        );
     }
 
     /**

--- a/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
+++ b/src/org/apache/xerces/impl/dv/xs/TypeValidator.java
@@ -39,7 +39,7 @@ import org.apache.xerces.util.XMLChar;
  */
 public abstract class TypeValidator {
     
-    private static boolean USE_CODE_POINT_COUNT_FOR_STRING_LENGTH = AccessController.doPrivileged(new PrivilegedAction() {
+    private static final boolean USE_CODE_POINT_COUNT_FOR_STRING_LENGTH = AccessController.doPrivileged(new PrivilegedAction() {
         @Override
         public Object run() {
             try {

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -25,8 +25,22 @@ import org.apache.xerces.xs.ItemPSVI;
  */
 public class SurrogatePairLengthTest extends BaseTest {
 
-    static {
-        System.setProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength", "true");
+    private static final String PROPERTY = "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength";
+    private String originalProperty;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        originalProperty = System.getProperty(PROPERTY);
+        System.setProperty(PROPERTY, "true");
+    }
+
+    protected void tearDown() throws Exception {
+        if (originalProperty != null) {
+            System.setProperty(PROPERTY, originalProperty);
+        } else {
+            System.clearProperty(PROPERTY);
+        }
+        super.tearDown();
     }
 
     protected String getXMLDocument() {

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -17,6 +17,9 @@
 
 package schema.config;
 
+import java.lang.reflect.Field;
+
+import org.apache.xerces.impl.dv.xs.TypeValidator;
 import org.apache.xerces.xs.ElementPSVI;
 import org.apache.xerces.xs.ItemPSVI;
 
@@ -27,16 +30,29 @@ public class SurrogatePairLengthTest extends BaseTest {
 
     private static final String PROPERTY = "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength";
     private static final String LENGTH_ERROR = "cvc-length-valid";
+    private static final Field codePointCountField;
+    
+    static {
+        try {
+            Field f = TypeValidator.class.getDeclaredField("USE_CODE_POINT_COUNT_FOR_STRING_LENGTH");
+            f.setAccessible(true);
+            codePointCountField = f;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
     
     // Tests run sequentially within a shared JVM, so setUp/tearDown
-    // can safely set and reset the system property before each test.
+    // can safely set and reset the flag before each test.
     protected void setUp() throws Exception {
         super.setUp();
         System.setProperty(PROPERTY, "true");
+        codePointCountField.set(null, true);
     }
     
     protected void tearDown() throws Exception {
         System.clearProperty(PROPERTY);
+        codePointCountField.set(null, false);
         super.tearDown();
     }
     

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -17,9 +17,6 @@
 
 package schema.config;
 
-import java.lang.reflect.Field;
-
-import org.apache.xerces.impl.dv.xs.TypeValidator;
 import org.apache.xerces.xs.ElementPSVI;
 import org.apache.xerces.xs.ItemPSVI;
 
@@ -28,25 +25,8 @@ import org.apache.xerces.xs.ItemPSVI;
  */
 public class SurrogatePairLengthTest extends BaseTest {
 
-    private Field codePointCountField;
-    private boolean originalCodePointCount;
-
-    protected void setUp() throws Exception {
-        super.setUp();
+    static {
         System.setProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength", "true");
-        Field f = TypeValidator.class.getDeclaredField("USE_CODE_POINT_COUNT_FOR_STRING_LENGTH");
-        f.setAccessible(true);
-        codePointCountField = f;
-        originalCodePointCount = f.getBoolean(null);
-        f.set(null, true);
-    }
-
-    protected void tearDown() throws Exception {
-        System.clearProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength");
-        if (codePointCountField != null) {
-            codePointCountField.set(null, originalCodePointCount);
-        }
-        super.tearDown();
     }
 
     protected String getXMLDocument() {

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -28,70 +28,63 @@ import org.apache.xerces.xs.ItemPSVI;
  */
 public class SurrogatePairLengthTest extends BaseTest {
 
-    private static final String PROPERTY = "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength";
-    private static final String LENGTH_ERROR = "cvc-length-valid";
-    private static final Field codePointCountField;
-    
-    static {
-        try {
-            Field f = TypeValidator.class.getDeclaredField("USE_CODE_POINT_COUNT_FOR_STRING_LENGTH");
-            f.setAccessible(true);
-            codePointCountField = f;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-    
-    // Tests run sequentially within a shared JVM, so setUp/tearDown
-    // can safely set and reset the flag before each test.
+    private Field codePointCountField;
+    private boolean originalCodePointCount;
+
     protected void setUp() throws Exception {
         super.setUp();
-        System.setProperty(PROPERTY, "true");
-        codePointCountField.set(null, true);
+        System.setProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength", "true");
+        Field f = TypeValidator.class.getDeclaredField("USE_CODE_POINT_COUNT_FOR_STRING_LENGTH");
+        f.setAccessible(true);
+        codePointCountField = f;
+        originalCodePointCount = f.getBoolean(null);
+        f.set(null, true);
     }
-    
+
     protected void tearDown() throws Exception {
-        System.clearProperty(PROPERTY);
-        codePointCountField.set(null, false);
+        System.clearProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength");
+        if (codePointCountField != null) {
+            codePointCountField.set(null, originalCodePointCount);
+        }
         super.tearDown();
     }
-    
+
     protected String getXMLDocument() {
         return "surrogate.xml";
     }
-    
+
     protected String getSchemaFile() {
         return "surrogate.xsd";
     }
-    
+
     protected String[] getRelevantErrorIDs() {
-        return new String[] { LENGTH_ERROR };
+        return new String[] { "cvc-length-valid" };
     }
-    
+
     public SurrogatePairLengthTest(String name) {
         super(name);
     }
-    
+
     public void testSetTrue() throws Exception {
         validateDocument();
         checkValidResult();
     }
-    
+
     private void checkValidResult() {
-        assertNoError(LENGTH_ERROR);
-        
+        assertNoError("cvc-length-valid");
+
         assertValidity(ItemPSVI.VALIDITY_VALID, fRootNode.getValidity());
         assertValidationAttempted(ItemPSVI.VALIDATION_FULL, fRootNode
                 .getValidationAttempted());
         assertElementName("root", fRootNode.getElementDeclaration().getName());
-        
+
         ElementPSVI child = super.getChild(1);
         assertValidity(ItemPSVI.VALIDITY_VALID, child.getValidity());
         assertValidationAttempted(ItemPSVI.VALIDATION_FULL, child
                 .getValidationAttempted());
         assertElementName("e1", child.getElementDeclaration().getName());
         assertTypeName("length", child.getTypeDefinition().getName());
-        
+
         child = super.getChild(2);
         assertValidity(ItemPSVI.VALIDITY_VALID, child.getValidity());
         assertValidationAttempted(ItemPSVI.VALIDATION_FULL, child

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -25,20 +25,24 @@ import org.apache.xerces.xs.ItemPSVI;
  */
 public class SurrogatePairLengthTest extends BaseTest {
 
-    private static final String PROPERTY = "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength";
     private String originalProperty;
 
     protected void setUp() throws Exception {
+        originalProperty = System.getProperty(
+            "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength");
+        System.setProperty(
+            "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength", "true");
         super.setUp();
-        originalProperty = System.getProperty(PROPERTY);
-        System.setProperty(PROPERTY, "true");
     }
 
     protected void tearDown() throws Exception {
         if (originalProperty != null) {
-            System.setProperty(PROPERTY, originalProperty);
+            System.setProperty(
+                "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength",
+                originalProperty);
         } else {
-            System.clearProperty(PROPERTY);
+            System.clearProperty(
+                "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength");
         }
         super.tearDown();
     }

--- a/tests/schema/config/SurrogatePairLengthTest.java
+++ b/tests/schema/config/SurrogatePairLengthTest.java
@@ -17,8 +17,6 @@
 
 package schema.config;
 
-import junit.framework.Assert;
-
 import org.apache.xerces.xs.ElementPSVI;
 import org.apache.xerces.xs.ItemPSVI;
 
@@ -27,12 +25,20 @@ import org.apache.xerces.xs.ItemPSVI;
  */
 public class SurrogatePairLengthTest extends BaseTest {
 
-    // Can only test when the property is set
-    static {
-        System.setProperty("org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength", "true");
+    private static final String PROPERTY = "org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength";
+    private static final String LENGTH_ERROR = "cvc-length-valid";
+    
+    // Tests run sequentially within a shared JVM, so setUp/tearDown
+    // can safely set and reset the system property before each test.
+    protected void setUp() throws Exception {
+        super.setUp();
+        System.setProperty(PROPERTY, "true");
     }
     
-    private static final String LENGTH_ERROR = "cvc-length-valid";
+    protected void tearDown() throws Exception {
+        System.clearProperty(PROPERTY);
+        super.tearDown();
+    }
     
     protected String getXMLDocument() {
         return "surrogate.xml";
@@ -50,15 +56,8 @@ public class SurrogatePairLengthTest extends BaseTest {
         super(name);
     }
     
-    // Can only test when the property is set
-    public void testSetTrue() {
-        try {
-            validateDocument();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Validation failed: " + e.getMessage());
-        }
-        
+    public void testSetTrue() throws Exception {
+        validateDocument();
         checkValidResult();
     }
     


### PR DESCRIPTION
`SurrogatePairLengthTest` requires setting a system property (`org.apache.xerces.impl.dv.xs.useCodePointCountForStringLength`) before `TypeValidator.class` loads. Since the class reads this property as a `static final` constant via `AccessController.doPrivileged(Boolean.getBoolean(...))`, it cannot run in the shared-JVM main `<batchtest>` (forkmode="once") — other tests load `TypeValidator` first, and the property is never read.

Added a separate `<junit>` task with `forkmode="perTest"` before the main batchtest to run this test in its own JVM, where the static initializer can set the property before any other class references `TypeValidator`.

Removed SurrogatePairLengthTest from the commented-out failure list since it now passes.